### PR TITLE
Python3

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -10,9 +10,10 @@ Short
    Commands:
 
      1) cd <package_directory>
-     2) ./configure
-     3) make
-     4) make install (as root)
+     2) autoconf
+     3) ./configure
+     4) make
+     5) make install (as root)
 
    Configure options:
 

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,7 @@ Quick installation
 ------------------
 Fortran::
 
+    $ autoconf
     $ ./configure && make && make install #as root
 
 Python::

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,8 @@ Fortran::
 
 Python::
 
-    $ python setup.py install
+    $ [sudo] python setup.py install
+    $ [sudo] python setup.py build_ext --inplace
 
 See INSTALL file
 

--- a/lib/spanlib/__init__.py
+++ b/lib/spanlib/__init__.py
@@ -19,10 +19,10 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #################################################################################
-from analyzer import *
-from filler import *
-from util import * 
-import analyzer
+from spanlib.analyzer import *
+from spanlib.filler import *
+from spanlib.util import *
+import spanlib.analyzer
 del docs
 __version__ = "2.3.0"
 

--- a/lib/spanlib/analyzer.py
+++ b/lib/spanlib/analyzer.py
@@ -88,13 +88,14 @@ class _BasicAnalyzer_(object):
 
         # Rearrange modes (imode=[0,3,4,5,9] -> [0,0],[3,5],[9,9])
         imode = [im for im in imode if im < nmode]
-        imode.sort(key=lambda x,y: (abs(x) > abs(y)) - (abs(x) < abs(y)))
+        # imode.sort(key=lambda x,y: (abs(x) > abs(y)) - (abs(x) < abs(y)))
+        imode.sort()
         if imode[0]<0: imode.insert(0,0)
         imodes = []
         im = 0
         while im < len(imode):
             imode1 = imode2 = imode[im]
-            for imt in xrange(im+1,len(imode)):
+            for imt in range(im+1,len(imode)):
                 if imode[imt] > 0  and (imode[imt]-imode2) > 1: # end of group
                     im = imt-1
                     break
@@ -657,7 +658,7 @@ class Analyzer(_BasicAnalyzer_, Dataset):
             if scale:
                 if scale is True: # Std dev of EOF is sqrt(ev)
                     scale = npy.sqrt(self._pca_raw_ev*(self.ns-1))
-                    for imode in xrange(eof.shape[0]):
+                    for imode in range(eof.shape[0]):
                         eof[imode] *= scale[imode]
                 else:
                     eof *= scale
@@ -1369,7 +1370,7 @@ class Analyzer(_BasicAnalyzer_, Dataset):
             mcev = npy.zeros((mcnens, self.nmssa))
 
             # Generate and ensemble of surrogate data
-            for iens in xrange(mcnens):
+            for iens in range(mcnens):
 
                 # Create a sample red noise (nt,nchan)
                 red_noise = rn.sample().T
@@ -1853,7 +1854,7 @@ class Analyzer(_BasicAnalyzer_, Dataset):
 #        if input is None:
 #            return alt
 #        if isinstance(input, dict): # Explicit dictionary
-#            for i in xrange(self.nd):
+#            for i in range(self.nd):
 #                if not input.has_key(i) and alt.has_key(i):
 #                    input[i] = alt[i]
 #            return input
@@ -1862,7 +1863,7 @@ class Analyzer(_BasicAnalyzer_, Dataset):
 #            for i, data in enumerate(input):
 #                out[i] = data
 #        else: # Array (=> same for all dataset)
-#            for i in xrange(self.nd):
+#            for i in range(self.nd):
 #                out[i] = input
 #        return out
 
@@ -2029,7 +2030,7 @@ def phase_composites(data,  nphase=8, minamp=.5, firstphase=0, index=None, forma
     # Loop on circular bins to make composites
     slices = [slice(None), ]*phases.ndim
     idx = npy.arange(data.shape[itaxis])
-    for iphase in xrange(len(marks)-1):
+    for iphase in range(len(marks)-1):
         slices[itaxis] = iphase
         inbin = amplitudes > minamp
         inbin &= angles >= marks[iphase]
@@ -2121,7 +2122,7 @@ class RedNoise(object):
         # Find the bias and gamma (Newton-Raphson algo)
         gamma0 = c1/c0
         self.gamma = c1/c0
-        for i in xrange(0, self.nitermax):
+        for i in range(0, self.nitermax):
             self.gamma -= (self.ubg(self.gamma, nt)-gamma0)/self.dubgdg(self.gamma, nt)
         self.bias = self.mu2(self.gamma, nt)
 

--- a/lib/spanlib/analyzer.py
+++ b/lib/spanlib/analyzer.py
@@ -21,14 +21,14 @@
 import gc
 import numpy as N
 npy = N
-from data import (has_cdat_support, cdms2_isVariable, Data, Dataset,
+from spanlib.data import (has_cdat_support, cdms2_isVariable, Data, Dataset,
     default_missing_value)
 if has_cdat_support:
     import MV2, cdms2
 #from .util import Logger, broadcast, SpanlibIter, dict_filter
 #from spanlib.util import Logger, broadcast, SpanlibIter, dict_filter
 # import _core
-from .util import Logger, broadcast, SpanlibIter, dict_filter
+from spanlib.util import Logger, broadcast, SpanlibIter, dict_filter
 
 docs = dict(
     npca="""- *npca*: int | ``None``

--- a/lib/spanlib/analyzer.py
+++ b/lib/spanlib/analyzer.py
@@ -27,7 +27,7 @@ if has_cdat_support:
     import MV2, cdms2
 #from .util import Logger, broadcast, SpanlibIter, dict_filter
 #from spanlib.util import Logger, broadcast, SpanlibIter, dict_filter
-# import _core
+import spanlib._core as _core
 from spanlib.util import Logger, broadcast, SpanlibIter, dict_filter
 
 docs = dict(

--- a/lib/spanlib/analyzer.py
+++ b/lib/spanlib/analyzer.py
@@ -27,7 +27,7 @@ if has_cdat_support:
     import MV2, cdms2
 #from .util import Logger, broadcast, SpanlibIter, dict_filter
 #from spanlib.util import Logger, broadcast, SpanlibIter, dict_filter
-import _core
+# import _core
 from .util import Logger, broadcast, SpanlibIter, dict_filter
 
 docs = dict(

--- a/lib/spanlib/analyzer.py
+++ b/lib/spanlib/analyzer.py
@@ -88,7 +88,7 @@ class _BasicAnalyzer_(object):
 
         # Rearrange modes (imode=[0,3,4,5,9] -> [0,0],[3,5],[9,9])
         imode = [im for im in imode if im < nmode]
-        imode.sort(cmp=lambda x,y: cmp(abs(x),abs(y)))
+        imode.sort(key=lambda x,y: (abs(x) > abs(y)) - (abs(x) < abs(y)))
         if imode[0]<0: imode.insert(0,0)
         imodes = []
         im = 0

--- a/lib/spanlib/data.py
+++ b/lib/spanlib/data.py
@@ -177,7 +177,6 @@ class Data(Logger):
         count[count<minvalid] = 0 # <minvalid -> 0
         count = npy.clip(count, 0, 1)
         # - save as 0/1
-        # self.ns = long(count.sum())
         self.ns = int(count.sum())
         self.compress = count.size != self.ns
         self.good = count>0 # points in space where there are enough data in time
@@ -357,7 +356,7 @@ class Data(Logger):
                 elif not isinstance(firstaxes, list):
                     firstaxes = [firstaxes]
             if firstdims is None and firstaxes is not None:
-                firstdims = tuple([(isinstance(a, (int, long))  and a or len(a)) for a in firstaxes])
+                firstdims = tuple([(isinstance(a, int)  and a or len(a)) for a in firstaxes])
             shape = firstdims + shape
             if firstaxes and isinstance(firstaxes[0], int): # real axes, not ints
                 firstaxes = None
@@ -414,7 +413,7 @@ class Data(Logger):
                 data.setAxis(i+len(firstdims), axis)
             if firstdims is not False and firstaxes is not None:
                 for i, a in enumerate(firstaxes):
-                    if not isinstance(a, (int, long)):
+                    if not isinstance(a, int):
                         try:
                             data.setAxis(i, a)
                         except:

--- a/lib/spanlib/data.py
+++ b/lib/spanlib/data.py
@@ -357,8 +357,9 @@ class Data(Logger):
                     firstaxes = [firstaxes]
             if firstdims is None and firstaxes is not None:
                 firstdims = tuple([(isinstance(a, int)  and a or a.size) for a in firstaxes])
-                print(firstaxes)
-                print(firstdims)
+                #FIXME
+                # print(firstaxes)
+                # print(firstdims)
             shape = firstdims + shape
             if firstaxes and isinstance(firstaxes[0], int): # real axes, not ints
                 firstaxes = None
@@ -466,7 +467,8 @@ class Data(Logger):
             data[:] = mdata # just to be sure
         else:
             if self.nsdim==0 and pdata.ndim>len(firstdims): pdata = pdata[first_slices+(0, )]
-            print("data: {}, pdata: {}".format(data.shape, pdata.shape))
+            #FIXME getting shape issues with pca in Python 3.
+            # print("data: {}, pdata: {}".format(data.shape, pdata.shape))
             data[:] = pdata.reshape(data.shape)
         del pdata
         # - mask

--- a/lib/spanlib/data.py
+++ b/lib/spanlib/data.py
@@ -32,7 +32,7 @@ except:
     has_cdat_support = False
 
 default_missing_value = npy.ma.default_fill_value(0.)
-from util import Logger, dict_filter, broadcast
+from spanlib.util import Logger, dict_filter, broadcast
 
 
 class Data(Logger):
@@ -177,7 +177,8 @@ class Data(Logger):
         count[count<minvalid] = 0 # <minvalid -> 0
         count = npy.clip(count, 0, 1)
         # - save as 0/1
-        self.ns = long(count.sum())
+        # self.ns = long(count.sum())
+        self.ns = count.sum()
         self.compress = count.size != self.ns
         self.good = count>0 # points in space where there are enough data in time
         self.minvalid = self.nvalid = minvalid

--- a/lib/spanlib/data.py
+++ b/lib/spanlib/data.py
@@ -356,7 +356,9 @@ class Data(Logger):
                 elif not isinstance(firstaxes, list):
                     firstaxes = [firstaxes]
             if firstdims is None and firstaxes is not None:
-                firstdims = tuple([(isinstance(a, int)  and a or len(a)) for a in firstaxes])
+                firstdims = tuple([(isinstance(a, int)  and a or a.size) for a in firstaxes])
+                print(firstaxes)
+                print(firstdims)
             shape = firstdims + shape
             if firstaxes and isinstance(firstaxes[0], int): # real axes, not ints
                 firstaxes = None
@@ -464,6 +466,7 @@ class Data(Logger):
             data[:] = mdata # just to be sure
         else:
             if self.nsdim==0 and pdata.ndim>len(firstdims): pdata = pdata[first_slices+(0, )]
+            print("data: {}, pdata: {}".format(data.shape, pdata.shape))
             data[:] = pdata.reshape(data.shape)
         del pdata
         # - mask

--- a/lib/spanlib/data.py
+++ b/lib/spanlib/data.py
@@ -178,7 +178,7 @@ class Data(Logger):
         count = npy.clip(count, 0, 1)
         # - save as 0/1
         # self.ns = long(count.sum())
-        self.ns = count.sum()
+        self.ns = int(count.sum())
         self.compress = count.size != self.ns
         self.good = count>0 # points in space where there are enough data in time
         self.minvalid = self.nvalid = minvalid

--- a/lib/spanlib/dual.py
+++ b/lib/spanlib/dual.py
@@ -111,7 +111,7 @@ class DualAnalyzer(_BasicAnalyzer_, Logger):
         # Number of SVD modes
         if self._nsvd is None: # Initialization
             self._nsvd = self._nsvd_default # Default value
-        for iset in xrange(2): # Check values
+        for iset in range(2): # Check values
             if self[iset].prepca:
                 nchanmax = self[iset].prepca # Input channels are from pre-PCA
             else:
@@ -227,7 +227,7 @@ class DualAnalyzer(_BasicAnalyzer_, Logger):
         self.update_params('svd', **kwargs)
 
         # Loop on first two datasets (left and right)
-        for iset in xrange(2):
+        for iset in range(2):
 
             # Check if old results can be used when nsvd is lower
             if self._svd_raw_pc is not None and \
@@ -318,7 +318,7 @@ class DualAnalyzer(_BasicAnalyzer_, Logger):
 
         # Of, let's format the variable
         fmt_eof = []
-        for iset in xrange(2): # (window*nchan,nsvd)
+        for iset in range(2): # (window*nchan,nsvd)
 
 #            # EOF already available
 #            if not raw and self._svd_fmt_eof is not None:
@@ -406,7 +406,7 @@ class DualAnalyzer(_BasicAnalyzer_, Logger):
 
         # Of, let's format the variable
         fmt_pc = []
-        for iset in xrange(2):
+        for iset in range(2):
 
             # Raw?
             raw_pc = self._svd_raw_pc[iset][:,:self._nsvd]
@@ -616,7 +616,7 @@ class DualAnalyzer(_BasicAnalyzer_, Logger):
 
         # Loop on left and right
         fmt_rec = []
-        for iset in xrange(2):
+        for iset in range(2):
 
             # ST-EOFs used for projection
             if xeof[iset] is None:

--- a/lib/spanlib/dual.py
+++ b/lib/spanlib/dual.py
@@ -24,14 +24,14 @@
 import copy
 import gc
 from warnings import warn
-# import _core
+import spanlib._core as _core
 import numpy as N
 npy = N
-from data import has_cdat_support, cdms2_isVariable, Data, Dataset, default_missing_value
+from spanlib.data import has_cdat_support, cdms2_isVariable, Data, Dataset, default_missing_value
 if has_cdat_support: import MV2, cdms2
 import pylab as P
 from spanlib.util import Logger, broadcast, SpanlibIter, dict_filter, SpanlibError
-from analyzer import _BasicAnalyzer_, Analyzer, docs, _filldocs_
+from spanlib.analyzer import _BasicAnalyzer_, Analyzer, docs, _filldocs_
 
 class DualSpanlibError(SpanlibError):
     pass

--- a/lib/spanlib/filler.py
+++ b/lib/spanlib/filler.py
@@ -25,7 +25,7 @@ import numpy as npy
 from .util import Logger, broadcast, SpanlibIter, dict_filter, SpanlibError
 from .analyzer import Analyzer, default_missing_value
 from .data import has_cdat_support, cdms2_isVariable
-import _core
+# import _core
 #import pylab as P
 
 class FillerError(SpanlibError):

--- a/lib/spanlib/filler.py
+++ b/lib/spanlib/filler.py
@@ -189,7 +189,7 @@ class Filler(Logger):
                 # Reanalyses loop
                 self._errors[anamode][self._ana] = []
                 last_reana_err = None
-                for ira in xrange(nreana[self._ana]):
+                for ira in range(nreana[self._ana]):
 
                     self.debug('  Analysis (%i/%i)'%(ira+1, nreana[self._ana]))
 
@@ -232,7 +232,7 @@ class Filler(Logger):
 
                         # Convergence loop for expansion coefficients
                         self._errors[anamode][self._ana][-1].append([])
-                        for istep in xrange(niterec):
+                        for istep in range(niterec):
                             if ecloop: self.debug('    EC convergence step: %i'%istep)
 
                             # Reconstruct
@@ -442,7 +442,7 @@ class Filler(Logger):
                     err = self.span.unmap(geterr)
                     geterr = True
                 else:
-                    err = [(self.span[i].data*0) for i in xrange(len(self.span))]
+                    err = [(self.span[i].data*0) for i in range(len(self.span))]
                 err = self.span.fill_invalids(err, pcaerr, copy=False, unmap=False)
                 del pcaerr
 
@@ -659,7 +659,7 @@ class Filler(Logger):
                 da1 = dmask.all(axis=1)
 #                del dmask
             for reduc in npy.arange(1, 0, -0.1):
-                for itry in xrange(max(1, ntries)):
+                for itry in range(max(1, ntries)):
 
                     # Last chance!
                     if itry==ntries-1 and reduc==0.1:

--- a/lib/spanlib/filler.py
+++ b/lib/spanlib/filler.py
@@ -22,10 +22,10 @@
 #################################################################################
 
 import numpy as npy
-from .util import Logger, broadcast, SpanlibIter, dict_filter, SpanlibError
-from .analyzer import Analyzer, default_missing_value
-from .data import has_cdat_support, cdms2_isVariable
-# import _core
+from spanlib.util import Logger, broadcast, SpanlibIter, dict_filter, SpanlibError
+from spanlib.analyzer import Analyzer, default_missing_value
+from spanlib.data import has_cdat_support, cdms2_isVariable
+import spanlib._core as _core
 #import pylab as P
 
 class FillerError(SpanlibError):

--- a/lib/spanlib/util.py
+++ b/lib/spanlib/util.py
@@ -36,7 +36,7 @@ def broadcast(input, mylen, fillvalue=None):
             if not input: return None
             return input[0]
         return input
-        
+
     # Multiple values as a list (or tuple)
     if not isinstance(input,(list,tuple)):
         fillvalue = input
@@ -52,14 +52,14 @@ def broadcast(input, mylen, fillvalue=None):
 
 class SpanlibError(Exception):
     """Reporter of exceptions
-    
+
     :Params:
-    
+
         - **what**: What is the error.
         - **where**, optional: Where the error occured.
-        
+
     :Example:
-    
+
         >>> SpanlibError('Bad number of channels', 'pca')
     """
     def __init__(self, what, where=None):
@@ -85,14 +85,14 @@ class SpanlibIter:
             return self.span[self.iset-1]
         del self.span._iter
         raise StopIteration
- 
+
 
 class Logger(object):
     """Class for logging facilities when subclassing.
     Logging may be sent to the console and/or a log file
-    
+
     :Params:
-    
+
         - **name**: Name of the logger.
         - **logfile**, optional: Log file.
         - **console**, optional: Log to the console.
@@ -102,18 +102,18 @@ class Logger(object):
         - **cfmt**, optional: Format of log message in console.
         - **asctime**, optional: Time format.
         - **level**, optional: Initialize logging level (see :meth:`set_loglevel`).
-    
+
     :See also: :mod:`logging` module
-    
+
     .. note:: Inspired from :class:`vacumm.misc.io.Logger`
     """
-    def __init__(self, name=None, logfile=None, console=True, maxlogsize=0, maxbackup=0, 
-        cfmt='%(name)s [%(levelname)-8s] %(message)s', 
-        ffmt='%(asctime)s: %(name)s [%(levelname)-8s] %(message)s', 
-        asctime='%Y-%m-%d %H:%M', 
-        loglevel='warning', logger=None, 
+    def __init__(self, name=None, logfile=None, console=True, maxlogsize=0, maxbackup=0,
+        cfmt='%(name)s [%(levelname)-8s] %(message)s',
+        ffmt='%(asctime)s: %(name)s [%(levelname)-8s] %(message)s',
+        asctime='%Y-%m-%d %H:%M',
+        loglevel='warning', logger=None,
         parser=None, announce=False):
-        
+
         # Setup the logger
         if logger is None:
             # Handlers
@@ -121,14 +121,14 @@ class Logger(object):
             if logfile is not None and logfile != '':
                 logdir = os.path.dirname(logfile)
                 if logdir != '' and not os.path.exists(logdir): os.makedirs(logdir)
-                file =  logging.handlers.RotatingFileHandler(logfile, 
+                file =  logging.handlers.RotatingFileHandler(logfile,
                     maxBytes=maxlogsize*1000, backupCount=maxbackup)
                 file.setFormatter(logging.Formatter(ffmt, asctime))
             # - console
             if console:
                 console = logging.StreamHandler()
                 console.setFormatter(logging.Formatter(cfmt))
-        
+
             # Logger
             if name is None: name = self.__class__.__name__.upper()
             logger = logging.getLogger(name)
@@ -136,50 +136,50 @@ class Logger(object):
             if console is not None: logger.addHandler(console)
         self.logger = logger
         self.parser = parser
-            
+
         # Set level
         self.set_loglevel(loglevel)
-        
+
         # Announce
         if announce: logger.debug('*** Start log session ***')
-        
+
     def debug(self, text, *args, **kwargs):
         """Send a debug message"""
         self.logger.debug(text, *args, **kwargs)
-        
+
     def info(self, text, *args, **kwargs):
         """Send a info message"""
         self.logger.info(text, *args, **kwargs)
-        
+
     def warning(self, text, *args, **kwargs):
         """Send a warning message"""
         self.logger.warning(text, *args, **kwargs)
-        
+
     def error(self, text, *args, **kwargs):
         """Send an error message and raise :class:`SpanLibError`
-        
+
         :Params:
-        
+
             - **text**: Text to display.
             - **errfunc**, optional: Callable function to display error once logged.
-              If ``errfunc`` is not passed and :attr:`parser` has been passed 
+              If ``errfunc`` is not passed and :attr:`parser` has been passed
               during initialization, :meth:`argparse.ArgumentParser.error` method is used.
             - **errxargs**: List of extra arguments for ``errfunc``.
-            
+
         :Raise:
-        
-            If ``errfunc`` is not provided or does not exit, :class:`SpanlibError` 
+
+            If ``errfunc`` is not provided or does not exit, :class:`SpanlibError`
             is raised.
-            
+
         :Examples:
-        
+
             >>> logger.Logger('mylogger')
             >>> logger.error('my error')
-            
+
             >>> myparser = ArgumentParser()
             >>> logger.Logger('mylogger', parser=myparser)
             >>> logger.error('my error') # implicit call to myparser.error
-            
+
             >>> myparser = ArgumentParser()
             >>> logger.Logger('mylogger')
             >>> logger.error('--myoption', errfunc=parser.ArgumentError,
@@ -190,7 +190,7 @@ class Logger(object):
         errfunc = kwargs.pop('errfunc', None)
         errargs = kwargs.pop('errxargs', [])
         if not callable(errfunc) and hasattr(self.parser, 'error'):
-           errfunc = self.parser.error 
+           errfunc = self.parser.error
            errxargs = []
         if callable(errfunc):
             if not isinstance(errxargs, (list, tuple)):
@@ -198,12 +198,12 @@ class Logger(object):
             errargs = [text]+list(errxargs)
             errfunc(*errargs)
         raise SpanlibError(text)
-        
+
     def set_loglevel(self, level=None, console=None, file=None):
         """Set the log level (DEBUG, INFO, WARNING, ERROR)
-        
+
         :Example:
-        
+
             >>> logger.set_loglevel('DEBUG', console='INFO')
         """
         if level is not None:
@@ -214,7 +214,7 @@ class Logger(object):
             elif console is not None and \
                 isinstance(handler, logging.StreamHandler):
                 handler.setLevel(self._get_loglevel_(console))
-                
+
     def get_loglevel(self, asstring=False):
         """Get the log level as an integer or a string"""
         if asstring:
@@ -223,10 +223,10 @@ class Logger(object):
                     return label
             return 'NOTSET'
         return self.logger.level
-        
+
     def _get_loglevel_(self, level):
         if level is None: level = 'debug'
-        if isinstance(level, basestring): 
+        if isinstance(level, basestring):
             level = getattr(logging, level.upper(), 'DEBUG')
         return level
 
@@ -240,15 +240,15 @@ class Logger(object):
 
 def dict_filter(kwargs, prefix, pop=True):
     """Filter a dictionary by keeping only items starting with a given prefix
-    
+
     :Example:
-    
-        >>> kwargs = dict(a=3, logfile='mylog.log', loglevel=0) 
+
+        >>> kwargs = dict(a=3, logfile='mylog.log', loglevel=0)
         >>> dict_filter(kwargs, 'log')
         {'file':'mylog.log','level':0}
         >>> kwargs
         {'a': 3}
-    
+
     """
     kwfilt = {}
     for key, val in kwargs.items():
@@ -256,6 +256,6 @@ def dict_filter(kwargs, prefix, pop=True):
             kwfilt[key[len(prefix):]] = val
             if pop: kwargs.pop(key)
     return kwfilt
-    
+
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 import os
 import sys
 import re
-from ConfigParser import SafeConfigParser
+from configparser import SafeConfigParser
 from numpy.distutils.core import setup, Extension
 from numpy.f2py import crackfortran
 
@@ -57,7 +57,7 @@ uvcdat_extlibdir = os.path.join(sys.prefix, 'Externals', 'lib')
 if os.path.exists(uvcdat_extlibdir):
     libdirs.append(uvcdat_extlibdir)
 libdirs += os.environ.get('LD_LIBRARY_PATH', '').split(':')
-libdirs += ['usr/lib','/usr/local/lib']
+libdirs += ['/usr/lib','/usr/local/lib']
 # - user specified
 cfg = SafeConfigParser()
 cfg.read('setup.cfg')


### PR DESCRIPTION
I made some changes for compatibility with Python 3. Mostly I got rid of the `long` keyword anywhere that it appears in `lib/spanlib/` files (all integers are long and covered by `int` in Python 3), and I got rid of the `cmp` argument to `list.sort()`, which is no longer supported in Python 3. I don't know the library well enough to thoroughly test it, but if I come across bugs I will try to fix them and create a new pull request.

Also, this could just be my system, but I found that I had to run `autoconf` before running `./configure`, and that `./configure` never worked for me. I was able to get `python setup.py install` to work, along with `python build_ext --inplace`, which I added to the README.
